### PR TITLE
Expand test runner coverage

### DIFF
--- a/tests/edge_signal.sh
+++ b/tests/edge_signal.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Script that kills itself with SIGKILL
+kill -9 $$

--- a/tests/edge_timeout.sh
+++ b/tests/edge_timeout.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Script that sleeps for a long time
+sleep 5


### PR DESCRIPTION
## Summary
- add edge case shell scripts for unit tests
- cover signal termination, timeouts, missing scripts and empty discovery in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68446d63e8788330abc6846e16fa6beb