### PR TITLE
Add reporting and metrics to test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ python3 test_runner.py [PATTERN ...] [options]
 - `-d, --directory DIR`  Directory containing test scripts (default: `tests`)
 - `-t, --timeout SECS`   Per-test timeout in seconds (default: 30)
 - `--coverage`           Collect coverage with `kcov` if installed
+- `--json`              Write JSON results to `test_results.json`
+- `--html`              Write HTML summary to `test_results.html`
+- `--report-dir DIR`    Output directory for reports
 
 If one or more `PATTERN` arguments are provided, only tests matching those glob
 patterns will be executed.
@@ -28,6 +31,7 @@ patterns will be executed.
 ## Example
 
 Run all tests:
+
 
 ```bash
 python3 test_runner.py
@@ -47,3 +51,8 @@ be executed with `pytest`:
 ```bash
 pytest pytests
 ```
+
+### Reporting
+
+Use `--json` or `--html` to generate reports in JSON or HTML format. Each
+result includes the exit code and duration so you can track metrics over time.

--- a/pytests/test_runner_test.py
+++ b/pytests/test_runner_test.py
@@ -29,14 +29,15 @@ def test_find_test_scripts_pattern():
 
 
 def test_run_test_success():
-    name, code, out, err = run_test(SUCCESS_SCRIPT)
+    name, code, out, err, dur = run_test(SUCCESS_SCRIPT)
     assert name == "test_success.sh"
     assert code == 0
     assert err == ""
+    assert dur >= 0
 
 
 def test_run_test_failure():
-    name, code, out, err = run_test(FAIL_SCRIPT)
+    name, code, out, err, dur = run_test(FAIL_SCRIPT)
     assert name == "test_fail.sh"
     assert code == 1
 
@@ -66,13 +67,13 @@ def test_run_all_tests_fail(tmp_path, caplog):
 
 
 def test_run_test_signal():
-    name, code, out, err = run_test(SIGNAL_SCRIPT)
+    name, code, out, err, dur = run_test(SIGNAL_SCRIPT)
     assert name == "edge_signal.sh"
     assert code == -9
 
 
 def test_run_test_timeout():
-    name, code, out, err = run_test(TIMEOUT_SCRIPT, timeout=1)
+    name, code, out, err, dur = run_test(TIMEOUT_SCRIPT, timeout=1)
     assert name == "edge_timeout.sh"
     assert code == -1
     assert "Timeout" in err
@@ -80,7 +81,7 @@ def test_run_test_timeout():
 
 def test_run_test_nonexistent():
     missing = TESTS_DIR / "missing.sh"
-    name, code, out, err = run_test(missing)
+    name, code, out, err, dur = run_test(missing)
     assert name == "missing.sh"
     assert code == 127
 
@@ -91,3 +92,21 @@ def test_run_all_tests_no_scripts(tmp_path):
     with pytest.raises(SystemExit) as exc:
         run_all_tests(str(dst), ["test_*.sh"], timeout=1, coverage=False)
     assert exc.value.code == 0
+
+
+def test_run_all_tests_reports(tmp_path):
+    dst = tmp_path / "tests"
+    dst.mkdir()
+    shutil.copy(SUCCESS_SCRIPT, dst / SUCCESS_SCRIPT.name)
+    with pytest.raises(SystemExit):
+        run_all_tests(
+            str(dst),
+            ["test_*.sh"],
+            timeout=5,
+            coverage=False,
+            json_report=True,
+            html_report=True,
+            report_dir=str(tmp_path),
+        )
+    assert (tmp_path / "test_results.json").exists()
+    assert (tmp_path / "test_results.html").exists()

--- a/test_runner.py
+++ b/test_runner.py
@@ -2,10 +2,37 @@ import subprocess
 import logging
 import argparse
 import shutil
+import json
+import time
 from pathlib import Path
-from typing import Iterable, List, Tuple
+from typing import Iterable, List, Tuple, Dict
 
 from colorama import Fore, Style, init
+
+
+def save_json_report(results: List[Dict], filename: Path) -> None:
+    """Write test results to a JSON file."""
+    with open(filename, "w") as f:
+        json.dump(results, f, indent=2)
+
+
+def save_html_report(results: List[Dict], filename: Path) -> None:
+    """Write a minimal HTML summary of test results."""
+    with open(filename, "w") as f:
+        f.write("<html><body><h1>Test Report</h1><table border='1'>")
+        f.write("<tr><th>Test</th><th>Status</th><th>Exit Code</th><th>Duration (s)</th></tr>")
+        for r in results:
+            color = {
+                0: "green",
+                -1: "orange",
+            }.get(r["exit_code"], "red")
+            f.write(
+                f"<tr><td>{r['name']}</td>"
+                f"<td style='color:{color}'>{'PASS' if r['exit_code']==0 else 'FAIL'}</td>"
+                f"<td>{r['exit_code']}</td>"
+                f"<td>{r['duration']:.2f}</td></tr>"
+            )
+        f.write("</table></body></html>")
 
 logging.basicConfig(
     level=logging.INFO,
@@ -28,8 +55,10 @@ def find_test_scripts(directory: str = "tests", patterns: Iterable[str] = ("test
     unique_scripts = {s.resolve() for s in scripts if s.is_file()}
     return sorted(unique_scripts)
 
-def run_test(script_path: Path, timeout: int = 30, coverage_dir: Path | None = None) -> Tuple[str, int, str, str]:
-    """Run a single test script and return its results."""
+def run_test(
+    script_path: Path, timeout: int = 30, coverage_dir: Path | None = None
+) -> Tuple[str, int, str, str, float]:
+    """Run a single test script and return its results with duration."""
     logger.info(f"Running: {script_path}")
     cmd = ["bash", str(script_path)]
     if coverage_dir:
@@ -40,29 +69,57 @@ def run_test(script_path: Path, timeout: int = 30, coverage_dir: Path | None = N
             coverage_dir.mkdir(parents=True, exist_ok=True)
             cmd = [kcov, str(coverage_dir), "bash", str(script_path)]
     try:
+        start = time.perf_counter()
         result = subprocess.run(
             cmd,
             capture_output=True,
             text=True,
             timeout=timeout,
-            check=False  # Don't raise even if exit code != 0
+            check=False,  # Don't raise even if exit code != 0
         )
-        return (script_path.name, result.returncode, result.stdout, result.stderr)
+        duration = time.perf_counter() - start
+        return (
+            script_path.name,
+            result.returncode,
+            result.stdout,
+            result.stderr,
+            duration,
+        )
     except subprocess.TimeoutExpired as e:
-        return (script_path.name, -1, "", f"Timeout after {timeout}s")
+        return (script_path.name, -1, "", f"Timeout after {timeout}s", timeout)
     except Exception as e:
-        return (script_path.name, -2, "", f"Unexpected error: {e}")
+        return (script_path.name, -2, "", f"Unexpected error: {e}", 0.0)
 
-def run_all_tests(directory: str, patterns: Iterable[str], timeout: int, coverage: bool):
-    """Run all discovered tests according to the provided options."""
+def run_all_tests(
+    directory: str,
+    patterns: Iterable[str],
+    timeout: int,
+    coverage: bool,
+    json_report: bool = False,
+    html_report: bool = False,
+    report_dir: str = ".",
+) -> None:
+    """Run all discovered tests and optionally write reports."""
     scripts = find_test_scripts(directory, patterns)
     logger.info(f"Found {len(scripts)} test scripts.")
 
     failures = []
+    results: List[Dict[str, object]] = []
     coverage_dir = Path("coverage") if coverage else None
     for script in scripts:
         coverage_path = coverage_dir / script.stem if coverage_dir else None
-        name, code, out, err = run_test(script, timeout=timeout, coverage_dir=coverage_path)
+        name, code, out, err, dur = run_test(
+            script, timeout=timeout, coverage_dir=coverage_path
+        )
+        results.append(
+            {
+                "name": name,
+                "exit_code": code,
+                "stdout": out,
+                "stderr": err,
+                "duration": dur,
+            }
+        )
         if code == 0:
             logger.info(Fore.GREEN + f"[PASS] {name}")
         else:
@@ -75,6 +132,14 @@ def run_all_tests(directory: str, patterns: Iterable[str], timeout: int, coverag
     logger.info(
         f"Total: {len(scripts)}, Passed: {len(scripts) - len(failures)}, Failed: {len(failures)}"
     )
+
+    report_path = Path(report_dir)
+    if json_report:
+        save_json_report(results, report_path / "test_results.json")
+        logger.info("JSON report saved.")
+    if html_report:
+        save_html_report(results, report_path / "test_results.html")
+        logger.info("HTML report saved.")
 
     if failures:
         logger.error(Fore.RED + "Failed Tests:")
@@ -91,7 +156,18 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--directory", default="tests", help="Directory containing test scripts")
     parser.add_argument("-t", "--timeout", type=int, default=30, help="Per-test timeout in seconds")
     parser.add_argument("--coverage", action="store_true", help="Collect coverage using kcov if available")
+    parser.add_argument("--json", action="store_true", help="Write JSON results to test_results.json")
+    parser.add_argument("--html", action="store_true", help="Write HTML summary to test_results.html")
+    parser.add_argument("--report-dir", default=".", help="Directory for output reports")
     args = parser.parse_args()
 
     patterns = args.tests if args.tests else ["test_*.sh"]
-    run_all_tests(args.directory, patterns, args.timeout, args.coverage)
+    run_all_tests(
+        args.directory,
+        patterns,
+        args.timeout,
+        args.coverage,
+        json_report=args.json,
+        html_report=args.html,
+        report_dir=args.report_dir,
+    )

--- a/test_runner.py
+++ b/test_runner.py
@@ -97,7 +97,7 @@ def run_all_tests(
     coverage: bool,
     json_report: bool = False,
     html_report: bool = False,
-    report_dir: str = ".",
+    report_dir: Path = Path("."),
 ) -> None:
     """Run all discovered tests and optionally write reports."""
     scripts = find_test_scripts(directory, patterns)


### PR DESCRIPTION
## Summary
- extend test runner with JSON/HTML reporting and per-test metrics
- support new CLI flags in `test_runner.py`
- document reporting options
- test coverage for new functionality

## Testing
- `pip install -q colorama`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844923136288330a6fba9253c9a7620