### PR TITLE
Add shell selection and permission checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 A simple Python-based test runner for shell scripts. Tests are discovered in the
 `tests/` directory by default and follow the pattern `test_*.sh`.
 
+Test scripts use `#!/usr/bin/env bash` shebangs so the correct Bash
+installation is located automatically.
+
+On macOS and Windows, ensure a Bash environment is available (e.g. via
+Homebrew, WSL or Git Bash) and that it appears on your `PATH`.
+
 ## Requirements
 
 Install dependencies via pip:
@@ -20,6 +26,8 @@ python3 test_runner.py [PATTERN ...] [options]
 
 - `-d, --directory DIR`  Directory containing test scripts (default: `tests`)
 - `-t, --timeout SECS`   Per-test timeout in seconds (default: 30)
+- `--shell SHELL`       Execute tests with the given shell (e.g. `bash`, `zsh`).
+  If omitted, each script's shebang is used.
 - `--coverage`           Collect coverage with `kcov` if installed
 - `--json`              Write JSON results to `test_results.json`
 - `--html`              Write HTML summary to `test_results.html`

--- a/tests/edge_signal.sh
+++ b/tests/edge_signal.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Script that kills itself with SIGKILL
 kill -9 $$

--- a/tests/edge_timeout.sh
+++ b/tests/edge_timeout.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Script that sleeps for a long time
 sleep 5

--- a/tests/test_fail.sh
+++ b/tests/test_fail.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # A simple test that fails
 exit 1

--- a/tests/test_success.sh
+++ b/tests/test_success.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # A simple test that succeeds
 exit 0

--- a/tests/test_tagged.sh
+++ b/tests/test_tagged.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Example tagged test
 # @slow
 exit 0


### PR DESCRIPTION
## Summary
- allow specifying `--shell` in `test_runner.py`
- check file readability and execute permissions
- respect shebang when no shell is provided
- update tests for new CLI option and permission cases
- document cross-platform notes and new option in README
- update test scripts to use `/usr/bin/env bash`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a35e2c748330ad1b15f89189c21f